### PR TITLE
Replace bzero/bcopy in libc

### DIFF
--- a/usr/src/lib/libc/amd64/sys/uadmin.c
+++ b/usr/src/lib/libc/amd64/sys/uadmin.c
@@ -42,6 +42,7 @@
 #include <sys/stat.h>
 #include <sys/uadmin.h>
 #include <unistd.h>
+#include <string.h>
 #include <strings.h>
 #include <pthread.h>
 #include <zone.h>
@@ -222,9 +223,9 @@ uadmin(int cmd, int fcn, uintptr_t mdep)
 				char *newarg, *head;
 				char bargs_scratch[BOOTARGS_MAX];
 
-				bzero(bargs_scratch, BOOTARGS_MAX);
+                               memset(bargs_scratch, 0, BOOTARGS_MAX);
 
-				bcopy(bargs, bargs_scratch, strlen(bargs));
+                               memcpy(bargs_scratch, bargs, strlen(bargs));
 				head = bargs_scratch;
 				newarg = strtok(bargs_scratch, " ");
 

--- a/usr/src/lib/libc/i386/sys/uadmin.c
+++ b/usr/src/lib/libc/i386/sys/uadmin.c
@@ -41,6 +41,7 @@
 #include <sys/stat.h>
 #include <sys/uadmin.h>
 #include <unistd.h>
+#include <string.h>
 #include <strings.h>
 #include <pthread.h>
 #include <zone.h>
@@ -222,9 +223,9 @@ uadmin(int cmd, int fcn, uintptr_t mdep)
 				char *newarg, *head;
 				char bargs_scratch[BOOTARGS_MAX];
 
-				bzero(bargs_scratch, BOOTARGS_MAX);
+                               memset(bargs_scratch, 0, BOOTARGS_MAX);
 
-				bcopy(bargs, bargs_scratch, strlen(bargs));
+                               memcpy(bargs_scratch, bargs, strlen(bargs));
 				head = bargs_scratch;
 				newarg = strtok(bargs_scratch, " ");
 

--- a/usr/src/lib/libc/port/gen/crypt.c
+++ b/usr/src/lib/libc/port/gen/crypt.c
@@ -36,6 +36,7 @@
 #include <dlfcn.h>
 #include <errno.h>
 #include <stdio.h>
+#include <string.h>
 #include <strings.h>
 #include <stdlib.h>
 #include <sys/time.h>
@@ -152,7 +153,7 @@ crypt(const char *plaintext, const char *salt)
 	ctbuffer = tsdalloc(_T_CRYPT, CRYPT_MAXCIPHERTEXTLEN, NULL);
 	if (ctbuffer == NULL)
 		return (NULL);
-	bzero(ctbuffer, CRYPT_MAXCIPHERTEXTLEN);
+       memset(ctbuffer, 0, CRYPT_MAXCIPHERTEXTLEN);
 
 	/*
 	 * '$' is never a possible salt char with the traditional unix
@@ -708,19 +709,19 @@ free_crypt_policy(struct crypt_policy_s *policy)
 		return;
 
 	if (policy->cp_default != NULL) {
-		bzero(policy->cp_default, strlen(policy->cp_default));
+               memset(policy->cp_default, 0, strlen(policy->cp_default));
 		free(policy->cp_default);
 		policy->cp_default = NULL;
 	}
 
 	if (policy->cp_allow != NULL) {
-		bzero(policy->cp_allow, strlen(policy->cp_allow));
+               memset(policy->cp_allow, 0, strlen(policy->cp_allow));
 		free(policy->cp_allow);
 		policy->cp_allow = NULL;
 	}
 
 	if (policy->cp_deny != NULL) {
-		bzero(policy->cp_deny, strlen(policy->cp_deny));
+               memset(policy->cp_deny, 0, strlen(policy->cp_deny));
 		free(policy->cp_deny);
 		policy->cp_deny = NULL;
 	}

--- a/usr/src/lib/libc/port/gen/getmntent.c
+++ b/usr/src/lib/libc/port/gen/getmntent.c
@@ -157,7 +157,7 @@ getmntany(FILE *fp, struct mnttab *mgetp, struct mnttab *mrefp)
 		errno = ENOMEM;
 		return (-1);
 	}
-	bzero(mgetp, sizeof (struct mnttab));
+       memset(mgetp, 0, sizeof (struct mnttab));
 	if (mrefp->mnt_special) {
 		mgetp->mnt_special = copyp;
 		copyp += snprintf(mgetp->mnt_special, MNT_LINE_MAX, "%s",

--- a/usr/src/lib/libc/port/gen/getut.c
+++ b/usr/src/lib/libc/port/gen/getut.c
@@ -159,7 +159,7 @@ getutent_frec(void)
 	/* Try to read in the next entry from the utmp file.  */
 
 	if (read(fd, &fubuf, sizeof (fubuf)) != sizeof (fubuf)) {
-		bzero(&fubuf, sizeof (fubuf));
+               memset(&fubuf, 0, sizeof (fubuf));
 		return (NULL);
 	}
 
@@ -398,8 +398,8 @@ _compat_setutent(void)
 	 * Zero the stored copy of the last entry read, since we are
 	 * resetting to the beginning of the file.
 	 */
-	bzero(&ubuf, sizeof (ubuf));
-	bzero(&fubuf, sizeof (fubuf));
+   memset(&ubuf, 0, sizeof (ubuf));
+   memset(&fubuf, 0, sizeof (fubuf));
 }
 
 /*
@@ -411,8 +411,8 @@ _compat_endutent(void)
 	if (fd != -1)
 		(void) close(fd);
 	fd = -1;
-	bzero(&ubuf, sizeof (ubuf));
-	bzero(&fubuf, sizeof (fubuf));
+   memset(&ubuf, 0, sizeof (ubuf));
+   memset(&fubuf, 0, sizeof (fubuf));
 }
 
 

--- a/usr/src/lib/libc/port/gen/getutx.c
+++ b/usr/src/lib/libc/port/gen/getutx.c
@@ -151,7 +151,7 @@ utmpx_frec2api(const struct futmpx *src, struct utmpx *dst)
 	dst->ut_tv.tv_sec = (time_t)src->ut_tv.tv_sec;
 	dst->ut_tv.tv_usec = (suseconds_t)src->ut_tv.tv_usec;
 	dst->ut_session = src->ut_session;
-	bzero(dst->pad, sizeof (dst->pad));
+       memset(dst->pad, 0, sizeof (dst->pad));
 	dst->ut_syslen = src->ut_syslen;
 	(void) memcpy(dst->ut_host, src->ut_host, sizeof (dst->ut_host));
 }
@@ -172,7 +172,7 @@ utmpx_api2frec(const struct utmpx *src, struct futmpx *dst)
 	dst->ut_tv.tv_sec = (time32_t)src->ut_tv.tv_sec;
 	dst->ut_tv.tv_usec = (int32_t)src->ut_tv.tv_usec;
 	dst->ut_session = src->ut_session;
-	bzero(dst->pad, sizeof (dst->pad));
+       memset(dst->pad, 0, sizeof (dst->pad));
 	dst->ut_syslen = src->ut_syslen;
 	(void) memcpy(dst->ut_host, src->ut_host, sizeof (dst->ut_host));
 }
@@ -227,7 +227,7 @@ getutxent_frec(void)
 		/*
 		 * Make sure fubuf is zeroed.
 		 */
-		bzero(&fubuf, sizeof (fubuf));
+               memset(&fubuf, 0, sizeof (fubuf));
 		return (NULL);
 	}
 
@@ -730,8 +730,8 @@ setutxent(void)
 	 * Zero the stored copy of the last entry read, since we are
 	 * resetting to the beginning of the file.
 	 */
-	bzero(&ubuf, sizeof (ubuf));
-	bzero(&fubuf, sizeof (fubuf));
+       memset(&ubuf, 0, sizeof (ubuf));
+       memset(&fubuf, 0, sizeof (fubuf));
 }
 
 /*
@@ -762,8 +762,8 @@ endutxent(void)
 		(void) fclose(fp);
 	fp = NULL;
 
-	bzero(&ubuf, sizeof (ubuf));
-	bzero(&fubuf, sizeof (fubuf));
+       memset(&ubuf, 0, sizeof (ubuf));
+       memset(&fubuf, 0, sizeof (fubuf));
 }
 
 /*
@@ -779,7 +779,7 @@ endutent(void)
 	}
 
 	endutxent();
-	bzero(&utmpcompat, sizeof (utmpcompat));
+       memset(&utmpcompat, 0, sizeof (utmpcompat));
 }
 
 /*
@@ -1360,10 +1360,10 @@ void
 getutmpx(const struct utmp *ut, struct utmpx *utx)
 {
 	(void) memcpy(utx->ut_user, ut->ut_user, sizeof (ut->ut_user));
-	(void) bzero(&utx->ut_user[sizeof (ut->ut_user)],
+       (void) memset(&utx->ut_user[sizeof (ut->ut_user)], 0,
 	    sizeof (utx->ut_user) - sizeof (ut->ut_user));
 	(void) memcpy(utx->ut_line, ut->ut_line, sizeof (ut->ut_line));
-	(void) bzero(&utx->ut_line[sizeof (ut->ut_line)],
+       (void) memset(&utx->ut_line[sizeof (ut->ut_line)], 0,
 	    sizeof (utx->ut_line) - sizeof (ut->ut_line));
 	(void) memcpy(utx->ut_id, ut->ut_id, sizeof (ut->ut_id));
 	utx->ut_pid = ut->ut_pid;
@@ -1372,8 +1372,8 @@ getutmpx(const struct utmp *ut, struct utmpx *utx)
 	utx->ut_tv.tv_sec = ut->ut_time;
 	utx->ut_tv.tv_usec = 0;
 	utx->ut_session = 0;
-	bzero(utx->pad, sizeof (utx->pad));
-	bzero(utx->ut_host, sizeof (utx->ut_host));
+       memset(utx->pad, 0, sizeof (utx->pad));
+       memset(utx->ut_host, 0, sizeof (utx->ut_host));
 	utx->ut_syslen = 0;
 }
 

--- a/usr/src/lib/libc/port/gen/getvfsent.c
+++ b/usr/src/lib/libc/port/gen/getvfsent.c
@@ -100,7 +100,7 @@ getvfsfile(FILE *fd, struct vfstab *vp, char *mountp)
 {
 	struct vfstab	vv;
 
-	bzero(&vv, (size_t)sizeof (vv));
+       memset(&vv, 0, sizeof (vv));
 	vv.vfs_mountp = mountp;
 	return (getvfsany(fd, vp, &vv));
 }

--- a/usr/src/lib/libc/port/gen/psecflags.c
+++ b/usr/src/lib/libc/port/gen/psecflags.c
@@ -46,7 +46,7 @@ secflags_parse(const secflagset_t *defaults, const char *flags,
 	boolean_t current = B_FALSE;
 
 	/* Guarantee a clean base */
-	bzero(ret, sizeof (*ret));
+       memset(ret, 0, sizeof (*ret));
 
 	if ((ss = s = strdup(flags)) == NULL)
 		return (-1);	/* errno set for us */

--- a/usr/src/lib/libc/port/gen/strndup.c
+++ b/usr/src/lib/libc/port/gen/strndup.c
@@ -41,7 +41,7 @@ strndup(const char *s1, size_t n)
 
 	n = strnlen(s1, n);
 	if ((s2 = malloc(n + 1)) != NULL) {
-		bcopy(s1, s2, n);
+               memcpy(s2, s1, n);
 		s2[n] = '\0';
 	}
 

--- a/usr/src/lib/libc/port/sys/inotify.c
+++ b/usr/src/lib/libc/port/sys/inotify.c
@@ -18,6 +18,7 @@
 #include <unistd.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <string.h>
 #include <strings.h>
 #include <dirent.h>
 
@@ -69,7 +70,7 @@ inotify_add_watch(int fd, const char *pathname, uint32_t mask)
 		return (-1);
 	}
 
-	bzero(&ioc, sizeof (ioc));
+       memset(&ioc, 0, sizeof (ioc));
 	ioc.inaw_fd = dirfd;
 	ioc.inaw_mask = mask;
 
@@ -96,7 +97,7 @@ inotify_add_watch(int fd, const char *pathname, uint32_t mask)
 		return (-1);
 	}
 
-	bzero(&cioc, sizeof (cioc));
+       memset(&cioc, 0, sizeof (cioc));
 	cioc.inac_fd = dirfd;
 
 	while ((dp = readdir(dir)) != NULL) {

--- a/usr/src/lib/libc/port/threads/pthr_attr.c
+++ b/usr/src/lib/libc/port/threads/pthr_attr.c
@@ -31,6 +31,7 @@
 #include "lint.h"
 #include "thr_uberdata.h"
 #include <sys/ctype.h>
+#include <string.h>
 #include <strings.h>
 #include <sched.h>
 
@@ -488,7 +489,7 @@ pthread_attr_setname_np(pthread_attr_t *attr, const char *name)
 		return (EINVAL);
 
 	if (name == NULL) {
-		bzero(ap->name, sizeof (ap->name));
+               memset(ap->name, 0, sizeof (ap->name));
 		return (0);
 	}
 
@@ -507,7 +508,7 @@ pthread_attr_setname_np(pthread_attr_t *attr, const char *name)
 	 * not having garbage after the end of the string simplifies attr
 	 * comparison
 	 */
-	bzero(ap->name, sizeof (ap->name));
+       memset(ap->name, 0, sizeof (ap->name));
 	(void) strlcpy(ap->name, name, sizeof (ap->name));
 	return (0);
 }

--- a/usr/src/lib/libc/sparc/gen/makectxt.c
+++ b/usr/src/lib/libc/sparc/gen/makectxt.c
@@ -33,6 +33,7 @@
 #include "lint.h"
 #include <stdarg.h>
 #include <strings.h>
+#include <string.h>
 /* Can't just use <ucontext.h> due to redefine_extname stuff. */
 #include <sys/ucontext.h>
 #include <sys/regset.h>
@@ -87,7 +88,7 @@ makecontext(ucontext_t *ucp, void (*func)(), int argc, ...)
 	 */
 	/* LINTED pointer cast may result in improper alignment */
 	tsp = &((struct frame *)sp)->fr_argd[0];
-	bzero(sp, sizeof (struct frame));
+       memset(sp, 0, sizeof (struct frame));
 
 	va_start(ap, argc);
 
@@ -134,7 +135,7 @@ __makecontext_v2(ucontext_t *ucp, void (*func)(), int argc, ...)
 	 */
 	/* LINTED pointer cast may result in improper alignment */
 	tsp = &((struct frame *)sp)->fr_argd[0];
-	bzero(sp, sizeof (struct frame));
+       memset(sp, 0, sizeof (struct frame));
 
 	va_start(ap, argc);
 

--- a/usr/src/lib/libc/sparcv9/gen/makectxt.c
+++ b/usr/src/lib/libc/sparcv9/gen/makectxt.c
@@ -33,6 +33,7 @@
 #include "lint.h"
 #include <stdarg.h>
 #include <strings.h>
+#include <string.h>
 /* Can't just use <ucontext.h> due to redefine_extname stuff. */
 #include <sys/ucontext.h>
 #include <sys/regset.h>
@@ -87,7 +88,7 @@ makecontext(ucontext_t *ucp, void (*func)(), int argc, ...)
 	 */
 	/* LINTED pointer cast may result in improper alignment */
 	tsp = &((struct frame *)sp)->fr_argd[0];
-	bzero(sp, sizeof (struct frame));
+       memset(sp, 0, sizeof (struct frame));
 
 	va_start(ap, argc);
 
@@ -134,7 +135,7 @@ __makecontext_v2(ucontext_t *ucp, void (*func)(), int argc, ...)
 	 */
 	/* LINTED pointer cast may result in improper alignment */
 	tsp = &((struct frame *)sp)->fr_argd[0];
-	bzero(sp, sizeof (struct frame));
+       memset(sp, 0, sizeof (struct frame));
 
 	va_start(ap, argc);
 


### PR DESCRIPTION
## Summary
- modernize libc by replacing deprecated `bzero`/`bcopy` with `memset` and `memcpy`
- add missing `<string.h>` includes

## Testing
- `git status --short`