### PR TITLE
Fix old types

### DIFF
--- a/usr/src/uts/common/fs/sockfs/sockfilter.c
+++ b/usr/src/uts/common/fs/sockfs/sockfilter.c
@@ -36,6 +36,7 @@
 #include <sys/socketvar.h>
 #include <fs/sockfs/sockcommon.h>
 #include <fs/sockfs/sockfilter_impl.h>
+#include <stdbool.h>
 
 /*
  * Socket Filter Framework
@@ -94,7 +95,7 @@ static sof_kstat_t	sof_stat;
 static kstat_t		*sof_stat_ksp;
 
 #ifdef DEBUG
-static int socket_filter_debug = 0;
+static bool socket_filter_debug = false;
 #endif
 
 /*

--- a/usr/src/uts/intel/io/hyperv/vmbus/vmbus.c
+++ b/usr/src/uts/intel/io/hyperv/vmbus/vmbus.c
@@ -61,14 +61,16 @@
 #include <sys/x86_archext.h>
 #include <sys/sunndi.h>
 #include <sys/ddi_subrdefs.h>
+#include <stdint.h>
+#include <stdbool.h>
 
 #define	curcpu	CPU->cpu_id
 
 #define	VMBUS_GPADL_START		0xe1e10
 
 #ifdef	DEBUG
-int vmbus_debug = 0;
-int vmbus_ndi_debug = 0;
+bool vmbus_debug = false;
+bool vmbus_ndi_debug = false;
 #endif
 
 struct vmbus_msghc {
@@ -134,8 +136,8 @@ vmbus_msghc_reset(struct vmbus_msghc *mh, size_t dsize)
 {
 	struct hypercall_postmsg_in *inprm;
 
-	if (dsize > HYPERCALL_POSTMSGIN_DSIZE_MAX)
-		panic("invalid data size %llu", (u_longlong_t)dsize);
+        if (dsize > HYPERCALL_POSTMSGIN_DSIZE_MAX)
+                panic("invalid data size %llu", (unsigned long long)dsize);
 
 	inprm = vmbus_xact_req_data(mh->mh_xact);
 	(void) memset(inprm, 0, HYPERCALL_POSTMSGIN_SIZE);
@@ -150,8 +152,8 @@ vmbus_msghc_get(struct vmbus_softc *sc, size_t dsize)
 	struct vmbus_msghc *mh = NULL;
 	struct vmbus_xact *xact;
 
-	if (dsize > HYPERCALL_POSTMSGIN_DSIZE_MAX)
-		panic("invalid data size %llu", (u_longlong_t)dsize);
+        if (dsize > HYPERCALL_POSTMSGIN_DSIZE_MAX)
+                panic("invalid data size %llu", (unsigned long long)dsize);
 
 	xact = vmbus_xact_get(sc->vmbus_xc,
 	    dsize + offsetof(struct hypercall_postmsg_in, hc_data[0]));
@@ -882,8 +884,8 @@ vmbus_synic_setup(void *xsc)
 		orig = rdmsr(sint);
 		val = sc->vmbus_idtvec | MSR_HV_SINT_AUTOEOI |
 		    (orig & MSR_HV_SINT_RSVD_MASK);
-		dev_err(sc->vmbus_dev, CE_CONT, "?SINT val %llx\n",
-		    (u_longlong_t)val);
+                dev_err(sc->vmbus_dev, CE_CONT, "?SINT val %llx\n",
+                    (unsigned long long)val);
 		wrmsr(sint, val);
 
 		/*

--- a/usr/src/uts/intel/io/hyperv/vmbus/vmbus_var.h
+++ b/usr/src/uts/intel/io/hyperv/vmbus/vmbus_var.h
@@ -50,6 +50,8 @@
 
 #include <sys/hyperv_busdma.h>
 #include <sys/hyperv_illumos.h>
+#include <stdbool.h>
+#include <stdint.h>
 
 /*
  * Specify the SINTs (synthetic interrupt sources) to use for vmbus messages
@@ -149,11 +151,11 @@ struct vmbus_softc {
 #define	VMBUS_PCPU_PTR(sc, field, cpu)	&(sc)->vmbus_pcpu[(cpu)].field
 
 #ifdef DEBUG
-extern int vmbus_debug;
+extern bool vmbus_debug;
 
 #define	VMBUS_DEBUG(sc, ...)						\
 	do {								\
-		if (__predict_false(vmbus_debug > 0)) {			\
+		if (__predict_false(vmbus_debug)) {			\
 			dev_err((sc)->vmbus_dev, CE_CONT, __VA_ARGS__);	\
 		}							\
 	} while (0)


### PR DESCRIPTION
## Summary
- use `bool` for vmbus debug flags
- use `<stdbool.h>` and `<stdint.h>`
- fix old `u_longlong_t` casts
- use `bool` for sock filter debug flag

## Testing
- `true`