### PR TITLE
Add restrict qualifiers and inline helpers

### DIFF
--- a/usr/src/cmd/mdb/common/libstand/sys/salib.h
+++ b/usr/src/cmd/mdb/common/libstand/sys/salib.h
@@ -49,10 +49,10 @@ extern void getopt_reset(void);
 
 extern void *memchr(const void *, int, size_t);
 extern int memcmp(const void *, const void *, size_t);
-extern void *memcpy(void *, const void *, size_t);
+extern void *memcpy(void *restrict, const void *restrict, size_t);
 extern void *memccpy(void *, const void *, int, size_t);
 extern void *memmove(void *, const void *, size_t);
-extern void *memset(void *, int, size_t);
+extern void *memset(void *restrict, int, size_t);
 
 extern void qsort(void *, size_t, size_t, int (*)(const void *,
     const void *));

--- a/usr/src/cmd/mdb/common/mdb/mdb_modapi.h
+++ b/usr/src/cmd/mdb/common/mdb/mdb_modapi.h
@@ -430,7 +430,7 @@ extern int bcmp(const void *, const void *, size_t);
 extern void bcopy(const void *, void *, size_t);
 extern void bzero(void *, size_t);
 
-extern void *memcpy(void *, const void *, size_t);
+extern void *memcpy(void *restrict, const void *restrict, size_t);
 extern void *memmove(void *, const void *, size_t);
 extern int memcmp(const void *, const void *, size_t);
 /* Need to be consistent with <string.h> C++ definitions */

--- a/usr/src/common/util/getoptstr.c
+++ b/usr/src/common/util/getoptstr.c
@@ -105,7 +105,7 @@ getoptstr(struct gos_params *params)
 		/* Check for "--" */
 		if (strp[1] == '-' && ISNTWORDCH(strp[2])) {
 			params->gos_strp = &strp[2];
-			SKIP_SPC(params->gos_strp);
+                       skip_spc(&params->gos_strp);
 			return (-1);
 		}
 	}
@@ -117,7 +117,7 @@ getoptstr(struct gos_params *params)
 		++params->gos_pos;
 		if (ISNTWORDCH(strp[params->gos_pos])) {
 			params->gos_strp = &strp[params->gos_pos];
-			SKIP_SPC(params->gos_strp);
+                       skip_spc(&params->gos_strp);
 			params->gos_pos = 1;
 		}
 		return ('?');
@@ -130,7 +130,7 @@ getoptstr(struct gos_params *params)
 
 		if (ISNTWORDCH(*params->gos_strp)) {
 			/* The argument is in the next word. */
-			SKIP_SPC(params->gos_strp);
+                       skip_spc(&params->gos_strp);
 
 			if (*params->gos_strp == '\0') {
 				/* Not.  Missing argument. */
@@ -143,16 +143,16 @@ getoptstr(struct gos_params *params)
 		params->gos_optargp = params->gos_strp;
 
 		/* Advance to the next word. */
-		SKIP_WORD(params->gos_strp);
+               skip_word(&params->gos_strp);
 		params->gos_optarglen = params->gos_strp - params->gos_optargp;
-		SKIP_SPC(params->gos_strp);
+               skip_spc(&params->gos_strp);
 
 		params->gos_pos = 1;
 	} else {
 		++params->gos_pos;
 		if (ISNTWORDCH(strp[params->gos_pos])) {
 			params->gos_strp = &strp[params->gos_pos];
-			SKIP_SPC(params->gos_strp);
+                       skip_spc(&params->gos_strp);
 			params->gos_pos = 1;
 		}
 		params->gos_optargp = NULL;

--- a/usr/src/common/util/getoptstr.h
+++ b/usr/src/common/util/getoptstr.h
@@ -44,9 +44,26 @@ extern "C" {
  * These macros are defined here so getoptstr() callers can handle spaces and
  * words consistently.
  */
-#define	ISSPACE(c)	((c) == ' ' || (c) == '\t')
-#define	SKIP_WORD(cp)	while (*cp != '\0' && !ISSPACE(*cp)) ++cp;
-#define	SKIP_SPC(cp)	while (ISSPACE(*cp)) ++cp;
+static inline int
+isspace_ascii(int c)
+{
+    return (c == ' ' || c == '\t');
+}
+
+static inline void
+skip_word(const char **restrict cp)
+{
+    while (**cp != '\0' && !isspace_ascii(**cp))
+        (*cp)++;
+}
+
+static inline void
+skip_spc(const char **restrict cp)
+{
+    while (isspace_ascii(**cp))
+        (*cp)++;
+}
+    return (c == 
 
 
 struct gos_params {

--- a/usr/src/common/util/memcpy.c
+++ b/usr/src/common/util/memcpy.c
@@ -54,11 +54,11 @@
  * Return s
  */
 void *
-memcpy(void *s, const void *s0, size_t n)
+memcpy(void *restrict s, const void *restrict s0, size_t n)
 {
-	if (n != 0) {
-		char *s1 = s;
-		const char *s2 = s0;
+        if (n != 0) {
+                char *restrict s1 = s;
+                const char *restrict s2 = s0;
 
 		do {
 			*s1++ = *s2++;

--- a/usr/src/common/util/memcpy.h
+++ b/usr/src/common/util/memcpy.h
@@ -33,7 +33,7 @@
 extern "C" {
 #endif
 
-extern void *memcpy(void *, const void *, size_t);
+extern void *memcpy(void *restrict, const void *restrict, size_t);
 
 #ifdef __cplusplus
 }

--- a/usr/src/head/memory.h
+++ b/usr/src/head/memory.h
@@ -51,8 +51,8 @@ using std::memchr;
 #else
 extern void *memchr(const void *, int, size_t);
 #endif
-extern void *memcpy(void *, const void *, size_t);
-extern void *memset(void *, int, size_t);
+extern void *memcpy(void *restrict, const void *restrict, size_t);
+extern void *memset(void *restrict, int, size_t);
 extern int memcmp(const void *, const void *, size_t);
 
 #ifdef	__cplusplus

--- a/usr/src/lib/smbclnt/libfknsmb/common/sys/sunddi.h
+++ b/usr/src/lib/smbclnt/libfknsmb/common/sys/sunddi.h
@@ -88,8 +88,8 @@ extern void numtos(ulong_t, char *);
 extern void bcopy(const void *, void *, size_t);
 extern void bzero(void *, size_t);
 
-extern void *memcpy(void *, const  void  *, size_t);
-extern void *memset(void *, int, size_t);
+extern void *memcpy(void *restrict, const void *restrict, size_t);
+extern void *memset(void *restrict, int, size_t);
 extern void *memmove(void *, const void *, size_t);
 extern int memcmp(const void *, const void *, size_t) __PURE;
 

--- a/usr/src/uts/common/krtld/kobj_bootflags.c
+++ b/usr/src/uts/common/krtld/kobj_bootflags.c
@@ -69,10 +69,10 @@ bootflags(struct bootops *ops)
 		    cp[2] == 'd' && cp[3] == 'b' &&
 		    (cp[4] == ' ' || cp[4] == '	' || cp[4] == 0))
 			boothowto |= RB_KMDB;
-		SKIP_WORD(cp);		/* Skip the kernel's filename. */
+		skip_word(&cp);		/* Skip the kernel's filename. */
 	}
 #endif
-	SKIP_SPC(cp);
+	skip_spc(&cp);
 
 #if defined(_OBP)
 	/* skip bootblk args */

--- a/usr/src/uts/common/sys/sunddi.h
+++ b/usr/src/uts/common/sys/sunddi.h
@@ -486,8 +486,8 @@ extern void numtos(ulong_t, char *);
 extern void bcopy(const void *, void *, size_t);
 extern void bzero(void *, size_t);
 
-extern void *memcpy(void *, const  void  *, size_t);
-extern void *memset(void *, int, size_t);
+extern void *memcpy(void *restrict, const void *restrict, size_t);
+extern void *memset(void *restrict, int, size_t);
 extern void *memmove(void *, const void *, size_t);
 extern int memcmp(const void *, const void *, size_t) __PURE;
 /* Need to be consistent with <string.h> C++ definition for memchr() */

--- a/usr/src/uts/common/sys/systm.h
+++ b/usr/src/uts/common/sys/systm.h
@@ -504,8 +504,8 @@ char *strpbrk(const char *, const char *);
 void bcopy(const void *, void *, size_t);
 void bzero(void *, size_t);
 
-extern void *memset(void *, int, size_t);
-extern void *memcpy(void *, const void *, size_t);
+extern void *memset(void *restrict, int, size_t);
+extern void *memcpy(void *restrict, const void *restrict, size_t);
 extern void *memmove(void *, const void *, size_t);
 extern int memcmp(const void *, const void *, size_t);
 


### PR DESCRIPTION
## Summary
- annotate `memcpy` implementation and prototypes with `restrict`
- convert `getoptstr` parsing macros to inline functions using `restrict`
- update callers of former macros
- apply restrict to libc prototypes used by boot components

## Testing
- `git status --short`